### PR TITLE
Add friend decralation of shared_lock_guard for basic_shared_mutex.

### DIFF
--- a/include/boost/sam/basic_shared_mutex.hpp
+++ b/include/boost/sam/basic_shared_mutex.hpp
@@ -33,7 +33,7 @@ struct basic_shared_mutex
 {
   /// The executor type.
   using executor_type = Executor;
-  
+
   /// A constructor. @param exec The executor to be used by the mutex.
   explicit basic_shared_mutex(executor_type exec,
                        int concurrency_hint = BOOST_SAM_CONCURRENCY_HINT_DEFAULT)
@@ -154,6 +154,7 @@ private:
   template <typename>
   friend struct basic_shared_mutex;
   friend struct lock_guard;
+  friend struct shared_lock_guard;
 
   Executor           exec_;
   detail::shared_mutex_impl impl_;


### PR DESCRIPTION
## Issue

### Reproduce code

```cpp
#include <boost/asio.hpp>
#include <boost/sam.hpp>

namespace net = boost::asio;
namespace sam = boost::sam;

net::awaitable<void> coro_main() {
    auto exe = co_await net::this_coro::executor;
    sam::shared_mutex mtx{exe};
    auto lck = co_await sam::async_lock_shared(
        mtx,
        net::deferred
    );
    co_return;
}

int main() {
    net::io_context ioc;
    net::co_spawn(
        ioc.get_executor(),
        coro_main(),
        net::detached
    );
    ioc.run();
}
```

### Error

```
/home/kondo/work/async_shared_mutex_study/clb/_deps/sam-src/include/boost/sam/shared_lock_guard.hpp:59:95: error: 'impl_' is a private member of 'boost::sam::basic_shared_mutex<>'
   59 |   shared_lock_guard(basic_shared_mutex<Executor> &mtx, const std::adopt_lock_t &) : mtx_(&mtx.impl_)
      |                                                                                               ^
```

### Analysis

`shared_lock_guard` needs to access basic_shared_mutex's private member variables like `lock_guard`.
However, only `lock_guard` declares as friend.

## Solution

This PR adds `shared_lock_guard` declares as friend too.

